### PR TITLE
Renaming the only method in iterable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubob"
-version = "1.3.4"
+version = "2.0.0"
 edition = "2018"
 authors = ["Artyom Sakharilenko <kryvashek@gmail.com>"]
 description = "Structured output helpers for display mode "

--- a/src/instant/iterable.rs
+++ b/src/instant/iterable.rs
@@ -31,10 +31,10 @@ impl Kind for Passage {}
 
 /// Trait used to generalize over [IntoIterator]+[Copy] and [Iterator]+[Clone] types.
 /// Actual used source is defined via type parameter which should implement [Kind] trait.
-/// There can be some problems when type implements [Iterator] and Copy simultaneously: since every [Iterator]
+/// There can be some problems when type implements [Iterator] and [Copy] simultaneously: since every [Iterator]
 /// automatically implements [IntoIterator], and [Copy] implementation requires [Clone] implementation too, such
 /// type will suit both alternatives and will cause conflict until explicit [Kind] specified.
-/// Trait is not sealed, so any user can define own Iterable implementation.
+/// Trait is not sealed, so any user can define own [Iterable] implementation.
 #[cfg_attr(
     docsrs,
     doc(cfg(all(any(feature = "list", feature = "struct"), feature = "instant")))
@@ -42,14 +42,14 @@ impl Kind for Passage {}
 pub trait Iterable<K: Kind> {
     type Iter: Iterator;
 
-    fn iter(&self) -> Self::Iter;
+    fn iterate(&self) -> Self::Iter;
 }
 
 /// Implementation of [Iterable] for [IntoIterator]+[Copy] types - mostly for references onto [IntoIterator] types.
 impl<T: IntoIterator + Copy> Iterable<Source> for T {
     type Iter = <Self as IntoIterator>::IntoIter;
 
-    fn iter(&self) -> Self::Iter {
+    fn iterate(&self) -> Self::Iter {
         IntoIterator::into_iter(*self)
     }
 }
@@ -58,7 +58,7 @@ impl<T: IntoIterator + Copy> Iterable<Source> for T {
 impl<T: Iterator + Clone> Iterable<Passage> for T {
     type Iter = Self;
 
-    fn iter(&self) -> Self::Iter {
+    fn iterate(&self) -> Self::Iter {
         self.clone()
     }
 }

--- a/src/instant/list.rs
+++ b/src/instant/list.rs
@@ -45,13 +45,16 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         ListShow::new(f, self.alt)
-            .items_from_iter(self.val.iter())
+            .items_from_iter(self.val.iterate())
             .finish()
     }
 }
 
 #[cfg(feature = "embed")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "embed", feature = "list", feature = "instant"))))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "embed", feature = "list", feature = "instant")))
+)]
 impl<I, K> crate::EmbedList for InstantList<I, K>
 where
     K: Kind,
@@ -59,6 +62,6 @@ where
     <I::Iter as Iterator>::Item: Display,
 {
     fn embed(&self, show: &mut ListShow) {
-        show.items_from_iter(self.val.iter());
+        show.items_from_iter(self.val.iterate());
     }
 }

--- a/src/instant/struct.rs
+++ b/src/instant/struct.rs
@@ -45,13 +45,16 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         StructShow::new(f, self.alt)
-            .fields_from_iter(self.val.iter())
+            .fields_from_iter(self.val.iterate())
             .finish()
     }
 }
 
 #[cfg(feature = "embed")]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "embed", feature = "struct", feature = "instant"))))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "embed", feature = "struct", feature = "instant")))
+)]
 impl<I, K> crate::EmbedStruct for InstantStruct<I, K>
 where
     K: Kind,
@@ -59,6 +62,6 @@ where
     <I::Iter as Iterator>::Item: DisplayPair,
 {
     fn embed(&self, show: &mut StructShow) {
-        show.fields_from_iter(self.val.iter());
+        show.fields_from_iter(self.val.iterate());
     }
 }


### PR DESCRIPTION
Since `.iter()` is quite a popular method, having another one leads to collisions and makes usage of this crate less comfortable. Renaming it should help, but `Iterable` trait is public and will remain so, hence compatibility break and major version bump.